### PR TITLE
Explicitly set the version hxsl depends on.

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license" : "BSD",
     "description" : "HxSL : Haxe high level shader library",
 	"contributors" : ["ncannasse"],
-	"dependencies" : { "format" : "" },
+	"dependencies" : { "format" : "3.0.5" },
     "version" : "2.0.3",
 	"releasenote" : "New version with runtime compiler constants"
 }


### PR DESCRIPTION
To prevent breakage :)

If you could release a hotfix to hxsl 2.0.3 with just this change, that would be great. Otherwise any project that specifically depends on hxsl 2.0.3 (like flambe 4.0) will remain broken. I'm planning to release 4.1 with maybe an updated hxsl version, but 4.0 should still continue to work.
